### PR TITLE
Fix installation links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ installed if `rbenv install` is not already available.
 
 ```sh
 # with curl
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer | bash
 
 # alternatively, with wget
-wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
+wget -q https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer -O- | bash
 ```
 
 The installer script is meant for casual use on your own development machine.
@@ -30,8 +30,8 @@ You can verify the state of your rbenv installation with:
 
 ```sh
 # with curl
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
 # alternatively, with wget
-wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor -O- | bash
+wget -q https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor -O- | bash
 ```


### PR DESCRIPTION
Apparently, `https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer` link doesn't work now so my script that follows READMD's instruction fails. It seems `HEAD`  isn't a valid reference to get a raw file. Instead, we can use `main` to point `HEAD`.

I have attached the details.
 
<details>

```
% curl -fsSLv https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x155011400)
> GET /rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer HTTP/2
> Host: github.com
> user-agent: curl/7.79.1
> accept: */*
>
< HTTP/2 404
< server: GitHub.com
< date: Wed, 27 Apr 2022 13:12:13 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Accept-Encoding, Accept, X-Requested-With
< permissions-policy: interest-cohort=()
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< expect-ct: max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events translator.github.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src render.githubusercontent.com viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 192875
< x-github-request-id: CCD5:6BB3:49BA9E:4EEEFB:62694131
* The requested URL returned error: 404
* stopped the pause stream!
* Connection #0 to host github.com left intact
curl: (22) The requested URL returned error: 404
```

</details>

I updated README.md to replace `HEAD` with `main`. Alternatively, we can use another style of URL that is eventually redirected from the original URL format, like below. 

`https://raw.githubusercontent.com/rbenv/rbenv-installer/main/bin/rbenv-doctor`

Either way is fine to me but wanted to keep the existing approach for now.